### PR TITLE
Update Lilu Address and Idea for Deprecation Warning.

### DIFF
--- a/Scripts/kextbuilder.py
+++ b/Scripts/kextbuilder.py
@@ -49,7 +49,7 @@ class KextBuilder:
         if not self._get_temp():
             return None
         os.chdir(self.temp)
-        output = self.self.r.run({"args":[self.git, "clone", "https://github.com/vit9696/Lilu"], "stream" : self.debug})
+        output = self.self.r.run({"args":[self.git, "clone", "https://github.com/acidanthera/Lilu"], "stream" : self.debug})
         if not output[2]:
             exit(1)
 
@@ -77,7 +77,7 @@ class KextBuilder:
         if not os.path.exists(self.temp + "/Lilu"):
             # Only download if we need to
             print("    Downloading Lilu...")
-            output = self.r.run({"args":[self.git, "clone", "https://github.com/vit9696/Lilu"], "stream" : self.debug})
+            output = self.r.run({"args":[self.git, "clone", "https://github.com/acidanthera/Lilu"], "stream" : self.debug})
             if not output[2] == 0:
                 return None
         os.chdir("Lilu")

--- a/Scripts/plugins.json
+++ b/Scripts/plugins.json
@@ -354,7 +354,7 @@
       "Desc": "for most Intel LAN"
     }, 
     {
-      "URL": "git clone https://github.com/vit9696/Lilu", 
+      "URL": "git clone https://github.com/acidanthera/Lilu", 
       "Name": "Lilu", 
       "Desc": "for arbitrary kext, library, and program patching"
     }, 

--- a/Scripts/updater.py
+++ b/Scripts/updater.py
@@ -156,7 +156,8 @@ class Updater:
             return None
         try:
             if sys.version_info >= (3, 0):
-                d = plistlib.readPlist(path)
+                with open(path, 'rb') as p:
+                    d = plistlib.load(p)
             else:
                 p_string = self._get_output(["plutil", "-convert", "json", "-o", "-", "--", path ])[0]
                 d = json.loads(p_string)


### PR DESCRIPTION
Lilu's github address is now https://github.com/acidanthera/Lilu.

Update scripts to match. Thx.

Also, had an idea for fixing the deprecation warning.